### PR TITLE
update logrotate module to support Ubuntu Xenial

### DIFF
--- a/manifests/defaults.pp
+++ b/manifests/defaults.pp
@@ -6,15 +6,12 @@ class logrotate::defaults{
     'Debian': {
 
       if !defined( Logrotate::Conf['/etc/logrotate.conf'] ) {
-        case $::lsbdistcodename {
-          'trusty': {
-            logrotate::conf {'/etc/logrotate.conf':
-              su_group => 'syslog'
-            }
+        if versioncmp($::operatingsystemrelease, '14.04') >= 0 {
+          logrotate::conf {'/etc/logrotate.conf':
+            su_group => 'syslog'
           }
-          default: {
-            logrotate::conf {'/etc/logrotate.conf': }
-          }
+        } else {
+          logrotate::conf {'/etc/logrotate.conf': }
         }
       }
 


### PR DESCRIPTION
Ubuntu Xenial also needs syslog as the su_group

Change case statement to if so that su_group will be applied to Trusty and later
